### PR TITLE
Fix: Correct Docker build and enhance CI workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21' # Specify your Go version
+
+    - name: Run backend tests
+      working-directory: backend
+      run: go test ./...
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20' # Specify your Node.js version, adjust if needed
+
+    - name: Install frontend dependencies and run tests
+      working-directory: frontend
+      run: |
+        make test # This should handle npm install and npm test as per frontend/Makefile
+
+    - name: Build frontend
+      working-directory: frontend
+      run: make build # This should handle npm install and vite build as per frontend/Makefile
+
+    - name: Build the Docker image (Backend)
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Build the Go application
+FROM golang:1.21-alpine AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy go.mod and go.sum and download dependencies
+COPY backend/go.mod backend/go.sum ./backend/
+RUN cd backend && go mod download
+
+# Copy the entire backend source code
+COPY backend/ ./backend/
+
+# Set the working directory to the backend
+WORKDIR /app/backend/
+
+# Build the Go application
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/server ./cmd/server/main.go
+
+# Stage 2: Prepare the runtime environment
+FROM alpine:latest
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/server /app/server
+
+# Copy the configuration files
+COPY backend/configs /app/configs
+
+# Expose the port the backend serves on
+EXPOSE 8080
+
+# Set the entrypoint
+ENTRYPOINT ["/app/server"]


### PR DESCRIPTION
- Add a Dockerfile to the repository root for building the Go backend application.
- The Dockerfile uses a multi-stage build to create a minimal runtime image.

- Update the GitHub Actions workflow (`.github/workflows/docker-image.yml`) to:
  - Run backend tests (`go test ./...`).
  - Install frontend dependencies and run frontend tests (`make test` in frontend dir).
  - Build the frontend application (`make build` in frontend dir).
  - Build the Docker image for the backend.

This resolves the issue of the missing Dockerfile and implements the requested CI enhancements for testing and building both frontend and backend components.