### PR TITLE
Fix: Update CI configuration and document frontend asset status

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,9 +35,15 @@ jobs:
       run: |
         make test # This should handle npm install and npm test as per frontend/Makefile
 
+    # Note: The frontend is built here, but its static assets are not currently
+    # included in the Docker image built in the subsequent step.
+    # The Dockerfile would need to be modified to include these assets
+    # if the goal is a self-contained application image.
     - name: Build frontend
       working-directory: frontend
       run: make build # This should handle npm install and vite build as per frontend/Makefile
 
+    # Note: This Docker build currently only includes the backend application.
+    # Frontend assets built in previous steps are not packaged into this image.
     - name: Build the Docker image (Backend)
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -7,7 +7,6 @@ all: build
 install-deps:
 	@echo "Installing frontend dependencies..."
 	npm install --legacy-peer-deps
-	npm install @sveltejs/kit
 
 build: install-deps
 	@echo "Building frontend application..."


### PR DESCRIPTION
This commit addresses aspects of the GitHub Actions CI workflow:

1.  Optimized `frontend/Makefile` by removing a redundant `npm install @sveltejs/kit` command from the `install-deps` target. This dependency is already covered by `npm install` via `devDependencies` in `package.json`.

2.  Added comments to `.github/workflows/docker-image.yml` to clarify the current status of frontend assets. Specifically, it's now noted that while the frontend is built during the CI process, its static assets are not included in the Docker image produced by the existing Dockerfile. This highlights a potential area for future improvement if a unified frontend/backend image is desired.

No changes were made to branch specifications in the workflow, assuming 'master' remains the correct target branch. This set of changes aims to improve clarity and efficiency of the CI setup without altering core build logic or application code, adhering to the constraint of not running/changing underlying code.