### PR TITLE
Fix: Add test target to backend Makefile

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -46,6 +46,13 @@ tidy:
 	go mod tidy
 	@echo "Dependencies tidied."
 
+# Run tests
+.PHONY: test
+test:
+	@echo "Running tests..."
+	go test ./...
+	@echo "Tests complete."
+
 # Help
 .PHONY: help
 help:
@@ -55,4 +62,5 @@ help:
 	@echo "  run         - Build and run the application"
 	@echo "  clean       - Remove build artifacts"
 	@echo "  tidy        - Tidy Go module dependencies"
+	@echo "  test        - Run tests"
 	@echo "  help        - Show this help message"


### PR DESCRIPTION
The GitHub CI was failing for the backend because the `test` target was missing in the `backend/Makefile`. This change adds the `test` target, which executes `go test ./...`.

Note: While `make test` can now be executed, the backend tests themselves are currently failing to compile. This is due to issues with Go module dependencies, particularly an unresolved dependency on `github.com/water-classroom/water-classroom-monolith/internal/app`. This problem is outside the scope of this Makefile fix and requires separate investigation and resolution.