### PR TITLE
feat: Add backend tests and update Makefile

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -32,6 +32,13 @@ run: build
 	@echo "Running $(APP_NAME)... (Ensure configs are set up in ./configs/)"
 	@$(BINARY_PATH)
 
+# Test the application
+.PHONY: test
+test:
+	@echo "Running tests..."
+	go test ./...
+	@echo "Tests complete."
+
 # Clean build artifacts
 .PHONY: clean
 clean:
@@ -53,6 +60,7 @@ help:
 	@echo "  all         - Build the application (default)"
 	@echo "  build       - Build the application"
 	@echo "  run         - Build and run the application"
+	@echo "  test        - Run tests"
 	@echo "  clean       - Remove build artifacts"
 	@echo "  tidy        - Tidy Go module dependencies"
 	@echo "  help        - Show this help message"

--- a/backend/internal/auth/handlers_test.go
+++ b/backend/internal/auth/handlers_test.go
@@ -1,0 +1,415 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/internal/config"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Helper function to create a mock Application and AuthHandler
+func setupTestEnv(t *testing.T) (*AuthHandler, sqlmock.Sqlmock, *app.Application) {
+	gin.SetMode(gin.TestMode)
+
+	mockDb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA private key: %v", err)
+	}
+
+	testApp := &app.Application{
+		Logger: zap.NewNop(),
+		DB:     mockDb,
+		Config: &config.Config{
+			PasswordHashCost:     bcrypt.MinCost, // Use MinCost for tests
+			JWTIssuer:            "test-issuer",
+			JWTAudience:          "test-audience",
+			AccessTokenDuration:  time.Hour * 1,
+			RefreshTokenDuration: time.Hour * 24 * 7,
+			// JWTSecretKey: "test-secret-key-minimum-32-characters", // Not needed for RSA
+		},
+		PrivateKey: privateKey,
+		PublicKey:  &privateKey.PublicKey,
+	}
+
+	authHandler := &AuthHandler{App: testApp}
+	return authHandler, mock, testApp
+}
+
+// TestHandleRegister_Success
+func TestHandleRegister_Success(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet() // Ensure all expectations are met
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	registerReq := RegisterRequest{
+		Name:     "Test User",
+		Email:    "test@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(registerReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id FROM users WHERE email = \\$1").
+		WithArgs(registerReq.Email).
+		WillReturnError(sql.ErrNoRows)
+
+	mock.ExpectQuery("INSERT INTO users \\(display_name, email, password_hash\\) VALUES \\(\\$1, \\$2, \\$3\\) RETURNING id").
+		WithArgs(registerReq.Name, registerReq.Email, sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("new-user-id"))
+
+	authHandler.HandleRegister(c)
+
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	var userResp UserResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &userResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "new-user-id", userResp.ID)
+	assert.Equal(t, registerReq.Name, userResp.Name)
+	assert.Equal(t, registerReq.Email, userResp.Email)
+}
+
+func TestHandleRegister_UserAlreadyExists(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	registerReq := RegisterRequest{
+		Name:     "Test User",
+		Email:    "exists@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(registerReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id FROM users WHERE email = \\$1").
+		WithArgs(registerReq.Email).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("existing-user-id")) // User exists
+
+	authHandler.HandleRegister(c)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "User with this email already exists", errorResp["error"])
+}
+
+func TestHandleRegister_InvalidRequestPayload(t *testing.T) {
+	authHandler, _, _ := setupTestEnv(t) // No DB interaction expected
+	defer authHandler.App.DB.Close()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	// Invalid JSON (e.g., missing required fields or malformed)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/register", bytes.NewBufferString(`{"email":"bad"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	authHandler.HandleRegister(c)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Contains(t, errorResp["error"], "Invalid request payload")
+}
+
+func TestHandleRegister_PasswordHashingFails(t *testing.T) {
+	// This test is tricky because bcrypt.GenerateFromPassword is called directly.
+	// To make it fail, we could pass an extremely high cost, but that would slow down the test.
+	// Or, we could modify the handler to allow injecting a mock hasher, which is out of scope.
+	// For now, we'll assume bcrypt works as expected if inputs are valid.
+	// A more direct way to test bcrypt failure would be to pass an invalid salt or cost,
+	// but the handler uses a cost from config.
+	// We can simulate a failure by setting a config that causes bcrypt to error,
+	// for example, by setting an invalid PasswordHashCost if bcrypt had stricter validation on it,
+	// but bcrypt's GenerateFromPassword mainly fails on cost > MaxCost or < MinCost.
+	// Since we use MinCost, it's unlikely to fail unless a system error occurs.
+
+	// For the purpose of this exercise, we'll skip directly testing bcrypt failure
+	// as it requires more invasive changes or reliance on system conditions.
+	// However, if we could inject the hashing function:
+	// mockHasher := func(password []byte, cost int) ([]byte, error) { return nil, errors.New("bcrypt failed") }
+	// And then use this mockHasher in HandleRegister.
+	t.Skip("Skipping direct bcrypt failure test as it requires handler modification or specific system conditions.")
+}
+
+func TestHandleRegister_DatabaseErrorOnUserInsert(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	registerReq := RegisterRequest{
+		Name:     "Test User",
+		Email:    "testfail@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(registerReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id FROM users WHERE email = \\$1").
+		WithArgs(registerReq.Email).
+		WillReturnError(sql.ErrNoRows)
+
+	mock.ExpectQuery("INSERT INTO users \\(display_name, email, password_hash\\) VALUES \\(\\$1, \\$2, \\$3\\) RETURNING id").
+		WithArgs(registerReq.Name, registerReq.Email, sqlmock.AnyArg()).
+		WillReturnError(errors.New("database insert error"))
+
+	authHandler.HandleRegister(c)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Failed to create user", errorResp["error"])
+}
+
+func TestHandleRegister_DatabaseErrorCheckingExistingUser(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	registerReq := RegisterRequest{
+		Name:     "Test User",
+		Email:    "testcheckfail@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(registerReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id FROM users WHERE email = \\$1").
+		WithArgs(registerReq.Email).
+		WillReturnError(errors.New("database check error"))
+
+	authHandler.HandleRegister(c)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Database error", errorResp["error"])
+}
+
+
+// TestHandleLogin_Success
+func TestHandleLogin_Success(t *testing.T) {
+	authHandler, mock, testApp := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	loginReq := LoginRequest{
+		Email:    "test@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(loginReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(loginReq.Password), testApp.Config.PasswordHashCost)
+
+	mock.ExpectQuery("SELECT id, email, password_hash FROM users WHERE email = \\$1").
+		WithArgs(loginReq.Email).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password_hash"}).
+			AddRow("user-id-123", loginReq.Email, string(hashedPassword)))
+
+	// Assuming GenerateTokens works correctly if App is set up
+	// (PrivateKey, Config for issuer, audience, durations)
+	// No direct DB calls from GenerateTokens are assumed based on typical patterns
+	// unless RefreshTokenPersistence is enabled and part of GenerateTokens, which is not indicated.
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var loginResp LoginResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &loginResp)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, loginResp.AccessToken)
+	assert.NotEmpty(t, loginResp.RefreshToken)
+}
+
+func TestHandleLogin_UserNotFound(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	loginReq := LoginRequest{
+		Email:    "notfound@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(loginReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id, email, password_hash FROM users WHERE email = \\$1").
+		WithArgs(loginReq.Email).
+		WillReturnError(sql.ErrNoRows)
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Invalid credentials", errorResp["error"])
+}
+
+func TestHandleLogin_IncorrectPassword(t *testing.T) {
+	authHandler, mock, testApp := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	loginReq := LoginRequest{
+		Email:    "test@example.com",
+		Password: "wrongpassword",
+	}
+	reqBody, _ := json.Marshal(loginReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Correct password is "password123"
+	correctPassword := "password123"
+	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(correctPassword), testApp.Config.PasswordHashCost)
+
+	mock.ExpectQuery("SELECT id, email, password_hash FROM users WHERE email = \\$1").
+		WithArgs(loginReq.Email).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password_hash"}).
+			AddRow("user-id-123", loginReq.Email, string(hashedPassword)))
+
+	// bcrypt.CompareHashAndPassword will fail internally
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Invalid credentials", errorResp["error"])
+}
+
+func TestHandleLogin_InvalidRequestPayload(t *testing.T) {
+	authHandler, _, _ := setupTestEnv(t) // No DB interaction
+	defer authHandler.App.DB.Close()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBufferString(`{"email":"bad"}`)) // Malformed
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Contains(t, errorResp["error"], "Invalid request payload")
+}
+
+func TestHandleLogin_DatabaseErrorOnUserFetch(t *testing.T) {
+	authHandler, mock, _ := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	loginReq := LoginRequest{
+		Email:    "dbfail@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(loginReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	mock.ExpectQuery("SELECT id, email, password_hash FROM users WHERE email = \\$1").
+		WithArgs(loginReq.Email).
+		WillReturnError(errors.New("database fetch error"))
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Database error", errorResp["error"])
+}
+
+func TestHandleLogin_TokenGenerationFails(t *testing.T) {
+	// To simulate token generation failure, we can make PrivateKey nil
+	authHandler, mock, testApp := setupTestEnv(t)
+	defer authHandler.App.DB.Close()
+	defer mock.ExpectationsWereMet()
+
+	// Intentionally break something GenerateTokens needs
+	testApp.PrivateKey = nil // This should cause GenerateTokens to fail
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+
+	loginReq := LoginRequest{
+		Email:    "test@example.com",
+		Password: "password123",
+	}
+	reqBody, _ := json.Marshal(loginReq)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/login", bytes.NewBuffer(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(loginReq.Password), testApp.Config.PasswordHashCost)
+
+	mock.ExpectQuery("SELECT id, email, password_hash FROM users WHERE email = \\$1").
+		WithArgs(loginReq.Email).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "email", "password_hash"}).
+			AddRow("user-id-123", loginReq.Email, string(hashedPassword)))
+
+	authHandler.HandleLogin(c)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	var errorResp map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Failed to generate tokens", errorResp["error"])
+}

--- a/backend/internal/auth/integration_test.go
+++ b/backend/internal/auth/integration_test.go
@@ -1,0 +1,227 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/internal/config"
+	"github.com/water-classroom/backend/internal/router"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// testJWTPrivateKeyPKCS1 uses \\n for newlines as ParseJWTKeys expects this format.
+// This is a minimal, valid PKCS#1 RSA private key for testing purposes.
+const testJWTPrivateKeyPKCS1 = "-----BEGIN RSA PRIVATE KEY-----\\n" +
+	"MC4CAQACBQD2Tr1dAgMBAAECBQDm4c7BAgMA/asCAwD9qwIDAP2rAgMA/asC\\n" +
+	"-----END RSA PRIVATE KEY-----"
+
+// testJWTPublicKey uses \\n for newlines.
+// This is the corresponding public key.
+const testJWTPublicKey = "-----BEGIN PUBLIC KEY-----\\n" +
+	"MCwwDQYJKoZIhvcNAQEBBQADGwAwGAIRAPZOvV0CAwD9qwIBAQNz\\n" +
+	"-----END PUBLIC KEY-----"
+
+// applyMigrations reads .sql files from a directory and executes them on the db.
+// It sorts files by name before execution.
+func applyMigrations(t *testing.T, db *sql.DB, migrationDir string) {
+	t.Helper()
+	var migrationFiles []string
+
+	err := filepath.WalkDir(migrationDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".sql") {
+			// Only include files directly in migrationDir, not subdirectories
+			if filepath.Dir(path) == migrationDir {
+				migrationFiles = append(migrationFiles, path)
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err, "Error walking migration directory: %s. Ensure path is correct relative to test execution.", migrationDir)
+
+	sort.Strings(migrationFiles) // Ensure migrations are applied in order
+
+	t.Logf("Found %d migration files in %s", len(migrationFiles), migrationDir)
+
+	appliedCount := 0
+	for _, mfPath := range migrationFiles {
+		fileName := filepath.Base(mfPath)
+		if strings.HasPrefix(fileName, "001_") ||
+			strings.HasPrefix(fileName, "002_") ||
+			strings.HasPrefix(fileName, "003_") ||
+			strings.HasPrefix(fileName, "004_") {
+
+			t.Logf("Applying migration: %s", mfPath)
+			content, err := os.ReadFile(mfPath)
+			require.NoError(t, err, fmt.Sprintf("Error reading migration file: %s", mfPath))
+
+			_, err = db.Exec(string(content))
+			require.NoError(t, err, fmt.Sprintf("Error executing migration file: %s. SQL: %s", mfPath, string(content)))
+			appliedCount++
+		}
+	}
+	require.True(t, appliedCount >= 1, "Expected at least 001_auth_initial_schema.sql to be applied")
+	t.Logf("Applied %d migrations successfully.", appliedCount)
+}
+
+func setupIntegrationTest(t *testing.T) (*app.Application, *gin.Engine, *sql.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	// Generate a unique database name for each test run to avoid conflicts
+	// and ensure a clean state if not purely in-memory or if cache=shared behaves unexpectedly.
+	dbSourceName := fmt.Sprintf("file:%s_%d_integration_test.db?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"), time.Now().UnixNano())
+	t.Logf("Using database source: %s", dbSourceName)
+
+
+	cfg := &config.Config{
+		LogLevel: "debug", // Use debug for more verbose logs during testing
+		Env:      "test",
+		DBDriver: "sqlite3",
+		DBSource: dbSourceName,
+		PasswordHashCost: bcrypt.MinCost,
+		JWTIssuer: "test-issuer",
+		JWTAudience: "test-audience",
+		JWTPrivateKey: testJWTPrivateKeyPKCS1,
+		JWTPublicKey: testJWTPublicKey,
+		JWTAccessTokenExpiry:  time.Hour,
+		JWTRefreshTokenExpiry: time.Hour * 24,
+		DisableAuth: false,
+	}
+
+	logger, err := zap.NewDevelopment(zap.IncreaseLevel(zap.DebugLevel)) // Capture debug logs
+	require.NoError(t, err)
+	t.Cleanup(func() { logger.Sync() })
+
+
+	db, err := sql.Open(cfg.DBDriver, cfg.DBSource)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		t.Logf("Closing database: %s", dbSourceName)
+		db.Close()
+		// For mode=memory with cache=shared, the file might persist until all connections are closed.
+		// Explicitly trying to remove it might be needed if issues arise, but typically not.
+		// os.Remove(strings.Split(dbSourceName, "?")[0][5:]) // Attempt to remove if not purely in-memory
+	})
+
+	// Verify DB connection
+	err = db.Ping()
+	require.NoError(t, err, "Failed to ping database")
+	t.Log("Database connection successful and pinged.")
+
+	// Apply migrations
+	applyMigrations(t, db, "../../migrations")
+
+	application := &app.Application{
+		Config: cfg,
+		Logger: logger,
+		DB:     db,
+	}
+
+	err = ParseJWTKeys(application)
+	require.NoError(t, err, "Failed to parse JWT keys for application")
+	require.NotNil(t, application.PrivateKey, "Private key should be parsed")
+	require.NotNil(t, application.PublicKey, "Public key should be parsed")
+	t.Log("JWT Keys parsed successfully.")
+
+
+	engine := router.NewRouter(application)
+	apiV1 := engine.Group("/api/v1")
+	authHandler := &AuthHandler{App: application}
+	RegisterRoutes(apiV1, authHandler, nil) // authMiddleware is nil as /register is public
+	t.Log("Router and auth routes initialized.")
+
+	return application, engine, db
+}
+
+func TestRegisterUser_Integration(t *testing.T) {
+	_, engine, db := setupIntegrationTest(t)
+
+	server := httptest.NewServer(engine)
+	defer server.Close()
+	t.Logf("Test server running on: %s", server.URL)
+
+	registerURL := fmt.Sprintf("%s/api/v1/auth/register", server.URL)
+
+	payload := RegisterRequest{
+		Name:     "Integration Test User",
+		Email:    "integration-" + fmt.Sprintf("%d", time.Now().UnixNano()) + "@example.com", // Unique email
+		Password: "password123",
+	}
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	t.Logf("Attempting to register user with email: %s", payload.Email)
+	resp, err := http.Post(registerURL, "application/json", bytes.NewBuffer(payloadBytes))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "HTTP status code should be 201 Created")
+	t.Log("User registration returned StatusCreated.")
+
+	var userResp UserResponse
+	err = json.NewDecoder(resp.Body).Decode(&userResp)
+	require.NoError(t, err, "Failed to decode response body")
+
+	assert.NotEmpty(t, userResp.ID, "User ID should not be empty in response")
+	assert.Equal(t, payload.Name, userResp.Name, "Name in response should match request")
+	assert.Equal(t, payload.Email, userResp.Email, "Email in response should match request")
+	t.Logf("User response validated: ID=%s, Name=%s, Email=%s", userResp.ID, userResp.Name, userResp.Email)
+
+	// Verify in database
+	t.Logf("Verifying user in database with email: %s", payload.Email)
+	var dbUserID, dbEmail, dbPasswordHash string
+	var dbDisplayName string
+	row := db.QueryRowContext(context.Background(), "SELECT id, email, password_hash, display_name FROM users WHERE email = ?", payload.Email)
+	err = row.Scan(&dbUserID, &dbEmail, &dbPasswordHash, &dbDisplayName)
+	if err == sql.ErrNoRows {
+		t.Fatalf("User with email %s not found in database after registration.", payload.Email)
+	}
+	require.NoError(t, err, "Failed to query user from database")
+
+	assert.Equal(t, userResp.ID, dbUserID, "User ID in DB should match response")
+	assert.Equal(t, payload.Email, dbEmail, "Email in DB should match request")
+	assert.Equal(t, payload.Name, dbDisplayName, "Display name in DB should match request name")
+	assert.NotEmpty(t, dbPasswordHash, "Password hash should not be empty in DB")
+	t.Logf("User verified in database: ID=%s, Email=%s, Name=%s, HashNotEmpty=%t", dbUserID, dbEmail, dbDisplayName, dbPasswordHash != "")
+
+	err = bcrypt.CompareHashAndPassword([]byte(dbPasswordHash), []byte(payload.Password))
+	assert.NoError(t, err, "Hashed password in DB should match the provided password")
+	t.Log("Password hash comparison successful.")
+}
+
+// Minimal test for ParseJWTKeys to ensure our dummy keys work with it.
+func TestParseJWTKeys_WithDummyKeys(t *testing.T) {
+	cfg := &config.Config{
+		JWTPrivateKey: testJWTPrivateKeyPKCS1,
+		JWTPublicKey:  testJWTPublicKey,
+	}
+	appInstance := &app.Application{
+		Config: cfg,
+		Logger: zap.NewNop(), // Using Nop logger for this specific util test
+	}
+	err := ParseJWTKeys(appInstance)
+	require.NoError(t, err, "ParseJWTKeys should not error with the dummy keys")
+	assert.NotNil(t, appInstance.PrivateKey)
+	assert.NotNil(t, appInstance.PublicKey)
+}


### PR DESCRIPTION
I've added unit tests for the auth handlers (Register, Login) and an integration test for the user registration route. I also updated the Makefile with a 'test' target.

I initialized Go modules for the backend and corrected various import paths that were pointing to an incorrect module.

I fixed several build errors found during testing, including issues in auth handlers related to OAuth state cookies and incorrect config field names in the new test files.

Note: I identified pre-existing build errors in the 'internal/payment' package and partially addressed them, but some still remain. These errors prevent the full test suite from passing. Further work is needed to resolve these issues in 'internal/payment/handlers.go' and 'internal/payment/stripe_client.go'.