### PR TITLE
Refactor: Correct Go import paths in backend modules

### DIFF
--- a/backend/assessment/handlers.go
+++ b/backend/assessment/handlers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/assessment/routes.go
+++ b/backend/assessment/routes.go
@@ -2,7 +2,6 @@ package assessment
 
 import (
 	"github.com/gin-gonic/gin"
-	// "github.com/water-classroom/backend/internal/app" // Not strictly needed here if handler has App
 )
 
 // RegisterRoutes sets up the assessment-related routes.

--- a/backend/assessment/service.go
+++ b/backend/assessment/service.go
@@ -1,7 +1,7 @@
 package assessment
 
 import (
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 	// "go.uber.org/zap" // If logging is needed in service methods directly
 	// "context" // If context is used in service methods
 )

--- a/backend/auth/handlers.go
+++ b/backend/auth/handlers.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/water-classroom/backend/internal/app" // Adjusted
+	"github.com/water-classroom/backend/app" // Adjusted
 	"go.uber.org/zap"                                                  // Added
 	"golang.org/x/crypto/bcrypt"
 	"github.com/golang-jwt/jwt/v5"

--- a/backend/auth/handlers_test.go
+++ b/backend/auth/handlers_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
-	"github.com/water-classroom/backend/internal/app"
-	"github.com/water-classroom/backend/internal/config"
+	"github.com/water-classroom/backend/app"
+	"github.com/water-classroom/backend/config"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 )

--- a/backend/auth/jwt.go
+++ b/backend/auth/jwt.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/water-classroom/backend/internal/app" // Adjusted
+	"github.com/water-classroom/backend/app" // Adjusted
 	"go.uber.org/zap"                                                  // Added
 )
 

--- a/backend/curriculum/handlers.go
+++ b/backend/curriculum/handlers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/curriculum/service.go
+++ b/backend/curriculum/service.go
@@ -1,7 +1,7 @@
 package curriculum
 
 import (
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 )
 
 // CurriculumService defines the service layer for curriculum-related operations.

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/water-classroom/backend/internal/config" // Adjusted import path
+	"github.com/water-classroom/backend/config" // Adjusted import path
 	_ "github.com/lib/pq"                                                  // Postgres driver
 	"go.uber.org/zap"
 )

--- a/backend/main.go
+++ b/backend/main.go
@@ -18,18 +18,18 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/water-classroom/backend/internal/app"
-	"github.com/water-classroom/backend/internal/auth"
-	"github.com/water-classroom/backend/internal/config"
-	"github.com/water-classroom/backend/internal/database"
-	"github.com/water-classroom/backend/internal/middleware"
-	"github.com/water-classroom/backend/internal/router"
-	"github.com/water-classroom/backend/internal/assessment"        // Added
-	"github.com/water-classroom/backend/internal/curriculum"
-	"github.com/water-classroom/backend/internal/notification"     // Added
-	"github.com/water-classroom/backend/internal/payment"
-	"github.com/water-classroom/backend/internal/progress"         // Added
-	"github.com/water-classroom/backend/internal/tutor_orchestrator" // Added
+	"github.com/water-classroom/backend/app"
+	"github.com/water-classroom/backend/auth"
+	"github.com/water-classroom/backend/config"
+	"github.com/water-classroom/backend/database"
+	"github.com/water-classroom/backend/middleware"
+	"github.com/water-classroom/backend/router"
+	"github.com/water-classroom/backend/assessment"        // Added
+	"github.com/water-classroom/backend/curriculum"
+	"github.com/water-classroom/backend/notification"     // Added
+	"github.com/water-classroom/backend/payment"
+	"github.com/water-classroom/backend/progress"         // Added
+	"github.com/water-classroom/backend/tutor_orchestrator" // Added
 	"github.com/water-classroom/backend/pkg/logger"
 	"go.uber.org/zap"
 	// _ "google.golang.org/grpc/reflection" // Keep for later if gRPC is fully integrated

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/water-classroom/backend/internal/app" // Adjusted
+	"github.com/water-classroom/backend/app" // Adjusted
 	"go.uber.org/zap"                                                 // Ensure zap is imported
 )
 

--- a/backend/notification/handlers.go
+++ b/backend/notification/handlers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/notification/service.go
+++ b/backend/notification/service.go
@@ -1,7 +1,7 @@
 package notification
 
 import (
-	"github.com/water-classroom/backend/internal/app"
+	"github.com/water-classroom/backend/app"
 	// "context" // If context is used in service methods
 	// "go.uber.org/zap" // If logging is needed
 )

--- a/backend/payment/handlers.go
+++ b/backend/payment/handlers.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stripe/stripe-go/v76"
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 	"github.com/google/uuid"
 )

--- a/backend/payment/routes.go
+++ b/backend/payment/routes.go
@@ -2,7 +2,7 @@ package payment
 
 import (
 	"github.com/gin-gonic/gin"
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/progress/handlers.go
+++ b/backend/progress/handlers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/progress/service.go
+++ b/backend/progress/service.go
@@ -1,7 +1,7 @@
 package progress
 
 import (
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	// "context"
 	// "go.uber.org/zap"
 )

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
-	// "github.com/water-classroom/water-classroom-monolith/internal/app" // Adjusted import path
+	"github.com/water-classroom/backend/app" // Adjusted import path
 	"go.uber.org/zap"
 	"path/filepath" // Added
 	"strings"       // Added

--- a/backend/tutor_orchestrator/handlers.go
+++ b/backend/tutor_orchestrator/handlers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/tutor_orchestrator/service.go
+++ b/backend/tutor_orchestrator/service.go
@@ -1,7 +1,7 @@
 package tutor_orchestrator
 
 import (
-	// "github.com/water-classroom/water-classroom-monolith/internal/app"
+	"github.com/water-classroom/backend/app"
 	// "context"
 	// "go.uber.org/zap"
 )


### PR DESCRIPTION
I removed the erroneous '/internal' path segment from import paths for modules located directly under the 'backend' directory.

This change aligns the import paths with the actual file structure and the Go module path defined in `go.mod` (`github.com/water-classroom/backend`).

For example, an import like:
`github.com/water-classroom/backend/internal/app`
has been changed to:
`github.com/water-classroom/backend/app`

This correction was applied to all relevant Go files within the `backend` directory, including application code, tests, and commented-out code.