### PR TITLE
Fix various build errors

### DIFF
--- a/backend/auth/handlers.go
+++ b/backend/auth/handlers.go
@@ -502,8 +502,8 @@ func (h *AuthHandler) HandleGoogleCallback(c *gin.Context) {
 		HttpOnly: true, Secure: h.App.Config.Env == "production", Path: "/", SameSite: http.SameSiteLaxMode,
 	})
 
-	if c.Query("state") != oauthStateCookie.Value { // Corrected: oauthStateCookie.Value
-		h.App.Logger.Error("Invalid OAuth state", zap.String("query_state", c.Query("state")), zap.String("cookie_state", oauthStateCookie.Value))
+	if c.Query("state") != oauthStateCookie { // Corrected: oauthStateCookie.Value
+		h.App.Logger.Error("Invalid OAuth state", zap.String("query_state", c.Query("state")), zap.String("cookie_state", oauthStateCookie))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid state value."})
 		return
 	}

--- a/backend/payment/handlers.go
+++ b/backend/payment/handlers.go
@@ -85,7 +85,7 @@ func (ph *PaymentHandler) HandleCreatePaymentIntent(c *gin.Context) {
 		UserID:                userIDStr,
 		StripePaymentIntentID: pi.ID,
 		Amount:                pi.Amount,
-		Currency:              pi.Currency,
+		Currency:              string(pi.Currency),
 		Status:                string(pi.Status), // e.g., "requires_payment_method"
 		Description:           &req.Description,  // Save description from request
 		CreatedAt:             time.Now(),

--- a/backend/payment/routes.go
+++ b/backend/payment/routes.go
@@ -2,7 +2,6 @@ package payment
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/water-classroom/backend/app"
 	"go.uber.org/zap"
 )
 

--- a/backend/payment/stripe_client.go
+++ b/backend/payment/stripe_client.go
@@ -79,7 +79,7 @@ func NewStripeClient(application *app.Application, secretKey string) *StripeClie
 func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*stripe.PaymentIntent, error) {
 	if sc.SecretKey == "" { // Check if client was initialized without a key
 		sc.App.Logger.Error("Stripe client called without a secret key.")
-		return nil, stripe.InvalidRequestError{Msg: "Stripe client not configured with a secret key."}
+		return nil, &stripe.InvalidRequestError{Message: "Stripe client not configured with a secret key."}
 	}
 	params := &stripe.PaymentIntentParams{
 		Amount:   stripe.Int64(amount),
@@ -107,7 +107,7 @@ func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*str
 func (sc *StripeClient) HandleWebhook(payload []byte, signatureHeader string, webhookSecret string) (*stripe.Event, error) {
 	if webhookSecret == "" {
 		sc.App.Logger.Error("Stripe webhook secret is not configured.")
-		return nil, stripe.InvalidRequestError{Msg: "Stripe webhook secret not configured."}
+		return nil, &stripe.InvalidRequestError{Message: "Stripe webhook secret not configured."}
 	}
 	event, err := sc.WHClient.ConstructEvent(payload, signatureHeader, webhookSecret)
 	if err != nil {


### PR DESCRIPTION
### This commit addresses several build errors:

- auth/handlers.go: Corrected OAuth cookie access by using the string value directly instead of attempting to access a non-existent `.Value` field.
- payment/handlers.go: Explicitly converted `stripe.Currency` to `string` to prevent potential type mismatch issues during assignment.
- payment/stripe_client.go:
    - Fixed `stripe.InvalidRequestError` returns to provide a pointer (`&`) to the struct, as the `Error()` method has a pointer receiver.
    - Corrected the field name from `Msg` to `Message` when instantiating `stripe.InvalidRequestError`.
- payment/routes.go: Removed an unused import of the `app` package.

These changes should allow the project to compile successfully. Errors related to undefined Stripe constants (e.g., `stripe.ErrorTypeSignatureVerification`, `stripe.EventTypePaymentIntentRequiresPaymentMethod`) are expected to be resolved if the Stripe SDK version `v76.25.0` (as specified in `go.mod`) is correctly used during the build, as these constants are present in that version.