### PR TITLE
Fix: Correct Stripe API usage for v76

### DIFF
--- a/backend/payment/handlers.go
+++ b/backend/payment/handlers.go
@@ -140,7 +140,7 @@ func (ph *PaymentHandler) HandleStripeWebhook(c *gin.Context) {
 		isSignatureError := false
 		if stripeErr, ok := err.(*stripe.Error); ok {
 			errMsgLower = strings.ToLower(stripeErr.Msg)
-			if stripeErr.Type == stripe.ErrorTypeSignatureVerification {
+			if stripeErr.Type == stripe.ErrorTypeStripeSignatureVerification {
 				isSignatureError = true
 			}
 		}

--- a/backend/payment/stripe_client.go
+++ b/backend/payment/stripe_client.go
@@ -79,7 +79,7 @@ func NewStripeClient(application *app.Application, secretKey string) *StripeClie
 func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*stripe.PaymentIntent, error) {
 	if sc.SecretKey == "" { // Check if client was initialized without a key
 		sc.App.Logger.Error("Stripe client called without a secret key.")
-		return nil, &stripe.InvalidRequestError{Message: "Stripe client not configured with a secret key."}
+		return nil, &stripe.InvalidRequestError{Msg: "Stripe client not configured with a secret key."}
 	}
 	params := &stripe.PaymentIntentParams{
 		Amount:   stripe.Int64(amount),
@@ -107,7 +107,7 @@ func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*str
 func (sc *StripeClient) HandleWebhook(payload []byte, signatureHeader string, webhookSecret string) (*stripe.Event, error) {
 	if webhookSecret == "" {
 		sc.App.Logger.Error("Stripe webhook secret is not configured.")
-		return nil, &stripe.InvalidRequestError{Message: "Stripe webhook secret not configured."}
+		return nil, &stripe.InvalidRequestError{Msg: "Stripe webhook secret not configured."}
 	}
 	event, err := sc.WHClient.ConstructEvent(payload, signatureHeader, webhookSecret)
 	if err != nil {
@@ -135,7 +135,7 @@ func (sc *StripeClient) HandleWebhook(payload []byte, signatureHeader string, we
 	case stripe.EventTypePaymentIntentPaymentFailed:
 		sc.App.Logger.Info("PaymentIntent failed", zap.String("event_id", event.ID))
 		// Further processing: update DB record to 'failed', notify user, etc.
-	case stripe.EventTypePaymentIntentRequiresPaymentMethod:
+	case stripe.EventTypePaymentIntentRequiresAction:
 		sc.App.Logger.Info("PaymentIntent requires payment method", zap.String("event_id", event.ID))
 	case stripe.EventTypePaymentIntentProcessing:
 		sc.App.Logger.Info("PaymentIntent processing", zap.String("event_id", event.ID))


### PR DESCRIPTION
Corrects undefined Stripe types and fields due to changes in the Stripe Go library v76.

- Changed `stripe.ErrorTypeSignatureVerification` to `stripe.ErrorTypeStripeSignatureVerification` in `payment/handlers.go` for webhook signature error checking.
- Changed `Message` field to `Msg` in `stripe.InvalidRequestError` struct literals in `payment/stripe_client.go`.
- Changed `stripe.EventTypePaymentIntentRequiresPaymentMethod` to `stripe.EventTypePaymentIntentRequiresAction` in `payment/stripe_client.go` for handling payment intent events.