### PR TITLE
Fix: Correct Stripe API usage errors

### DIFF
--- a/backend/payment/handlers.go
+++ b/backend/payment/handlers.go
@@ -140,7 +140,7 @@ func (ph *PaymentHandler) HandleStripeWebhook(c *gin.Context) {
 		isSignatureError := false
 		if stripeErr, ok := err.(*stripe.Error); ok {
 			errMsgLower = strings.ToLower(stripeErr.Msg)
-			if stripeErr.Type == stripe.ErrorTypeStripeSignatureVerification {
+			if stripeErr.Type == stripe.ErrorTypeSignatureVerification {
 				isSignatureError = true
 			}
 		}

--- a/backend/payment/stripe_client.go
+++ b/backend/payment/stripe_client.go
@@ -79,7 +79,7 @@ func NewStripeClient(application *app.Application, secretKey string) *StripeClie
 func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*stripe.PaymentIntent, error) {
 	if sc.SecretKey == "" { // Check if client was initialized without a key
 		sc.App.Logger.Error("Stripe client called without a secret key.")
-		return nil, &stripe.InvalidRequestError{Msg: "Stripe client not configured with a secret key."}
+		return nil, &stripe.InvalidRequestError{Message: "Stripe client not configured with a secret key."}
 	}
 	params := &stripe.PaymentIntentParams{
 		Amount:   stripe.Int64(amount),
@@ -107,7 +107,7 @@ func (sc *StripeClient) CreatePaymentIntent(amount int64, currency string) (*str
 func (sc *StripeClient) HandleWebhook(payload []byte, signatureHeader string, webhookSecret string) (*stripe.Event, error) {
 	if webhookSecret == "" {
 		sc.App.Logger.Error("Stripe webhook secret is not configured.")
-		return nil, &stripe.InvalidRequestError{Msg: "Stripe webhook secret not configured."}
+		return nil, &stripe.InvalidRequestError{Message: "Stripe webhook secret not configured."}
 	}
 	event, err := sc.WHClient.ConstructEvent(payload, signatureHeader, webhookSecret)
 	if err != nil {


### PR DESCRIPTION
This commit addresses build failures related to Stripe API integration:

1.  Corrected the Stripe error type constant for signature verification in `payment/handlers.go`. Changed `stripe.ErrorTypeStripeSignatureVerification` to `stripe.ErrorTypeSignatureVerification` to match the v76 stripe-go library.

2.  Updated the field name used in `stripe.InvalidRequestError` struct literals in `payment/stripe_client.go`. Changed `Msg` to `Message` as the `Msg` field is not defined in this version of the library for this error type.

These changes ensure compatibility with the Stripe Go client library version being used and resolve the undefined type and unknown field errors.